### PR TITLE
feat: Enable backstage to connect to local cluster

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: backstage
 description: A helm chart for deploying Backstage
-version: 0.1.5
+version: 0.1.6
 appVersion: "v1.7.0"
 kubeVersion: ">= 1.19.0-0"
 home: https://github.com/redhat-developer/helm-backstage

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,6 +1,6 @@
 # backstage
 
-![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![AppVersion: v1.7.0](https://img.shields.io/badge/AppVersion-v1.7.0-informational?style=flat-square)
+![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![AppVersion: v1.7.0](https://img.shields.io/badge/AppVersion-v1.7.0-informational?style=flat-square)
 
 A helm chart for deploying Backstage
 
@@ -48,9 +48,11 @@ Replace `<RELEASE>` with the name of the Helm release that was used when install
 | image.repository | string | `"redhat-developer/redhat-backstage-build"` |  |
 | image.version | string | `"latest"` |  |
 | imagePullSecrets | list | `[]` |  |
+| ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.tls.secretName | string | `""` |  |
+| kubernetesPlugin.connectToLocal | bool | `false` |  |
 | name | string | `"backstage"` |  |
 | nameOverride | string | `""` |  |
 | postgres.database_host | string | `""` |  |

--- a/charts/backstage/templates/app-config.yaml
+++ b/charts/backstage/templates/app-config.yaml
@@ -89,6 +89,20 @@ stringData:
         {{- toYaml . | nindent 6 }}
       {{- end }}
 
+    {{- if .Values.kubernetesPlugin.connectToLocal }}
+    kubernetes:
+      serviceLocatorMethod:
+        type: "multiTenant"
+      clusterLocatorMethods:
+        - type: "config"
+          clusters:
+            - url: https://openshift.default.svc.cluster.local
+              name: local-cluster
+              authProvider: "serviceAccount"
+              skipTLSVerify: true
+              skipMetricsLookup: false
+    {{- end }}
+
 {{- if .Values.additionalConfig }}
   additional-config.yaml: |
     {{- toYaml .Values.additionalConfig | nindent 4 }}

--- a/charts/backstage/templates/clusterrole.yaml
+++ b/charts/backstage/templates/clusterrole.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.kubernetesPlugin.connectToLocal }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "backstage.fullname" . }}-{{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - services
+  - configmaps
+  - limitranges
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - watch
+  - list
+{{- end }}

--- a/charts/backstage/templates/clusterrolebinding.yaml
+++ b/charts/backstage/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.kubernetesPlugin.connectToLocal }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "backstage.fullname" . }}-{{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "backstage.fullname" . }}-{{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "backstage.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -18,6 +18,7 @@
         "resources",
         "serviceAccount",
         "securityContext",
+        "kubernetesPlugin",
         "backstage"
     ],
     "properties": {
@@ -699,6 +700,29 @@
                 {}
             ]
         },
+        "kubernetesPlugin": {
+            "type": "object",
+            "default": {},
+            "title": "Configuration of the Kubernetes plugin for Backstage",
+            "required": [
+                "connectToLocal"
+            ],
+            "properties": {
+                "connectToLocal": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "Configure the Backstage instance to connect to the local cluster",
+                    "examples": [
+                        true
+                    ]
+                }
+            },
+            "examples": [
+                {
+                    "connectToLocal": true
+                }
+            ]
+        },
         "backstage": {
             "type": "object",
             "default": {},
@@ -979,6 +1003,9 @@
                 "name": ""
             },
             "securityContext": {},
+            "kubernetesPlugin": {
+                "connectToLocal": false
+            },
             "backstage": {
                 "companyname": "Red Hat Backstage Helm Chart",
                 "baseUrl": "",

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -99,6 +99,11 @@ serviceAccount:
 
 securityContext: {}
 
+# Configuration of the Kubernetes plugin for Backstage
+kubernetesPlugin:
+  # Configure backstage to connect to your local cluster
+  connectToLocal: false
+
 ## There is a secret created via the template/
 backstage:
   companyname: "Red Hat Backstage Helm Chart"


### PR DESCRIPTION
Signed-off-by: Tomas Coufal <tcoufal@redhat.com>

<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves redhat-developer/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

If user has the kubernetes plugin installed in Backstage, this allows him to easily connect it to the local cluster. 

## Existing or Associated Issue(s)

n/a

## Additional Information

n/a

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
