### PR TITLE
feat: Add BuildConfig option to build the image in cluster

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -42,4 +42,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.1
+version: 2.1.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Janus-IDP Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/janus-idp&style=flat-square)](https://artifacthub.io/packages/search?repo=janus-idp)
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square)
+![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
@@ -133,6 +133,28 @@ Kubernetes: `>= 1.19.0-0`
 
 | Key | Description | Type | Default |
 |-----|-------------|------|---------|
+| build | Build Backstage image in-cluster | object | `{"buildConfig":{"annotations":{},"completionDeadlineSeconds":1800,"contextDir":"","failedBuildsHistoryLimit":5,"ref":"main","resources":{"limits":{"cpu":"500m","memory":"2Gi"}},"sourceSecretName":"","strategy":{"docker":{"dockerfilePath":"./Dockerfile","pullSecrets":[]},"source":{"scripts":"https://raw.githubusercontent.com/janus-idp/redhat-backstage-build/add-s2i/.s2i/bin/"},"type":"Source"},"successfulBuildsHistoryLimit":5,"triggers":[{"type":"ConfigChange"},{"type":"ImageChange"}],"uri":"https://github.com/janus-idp/backstage-showcase.git"},"enabled":false,"imageStream":{"annotations":{}}}` |
+| build.buildConfig | BuildConfig specific values | object | `{"annotations":{},"completionDeadlineSeconds":1800,"contextDir":"","failedBuildsHistoryLimit":5,"ref":"main","resources":{"limits":{"cpu":"500m","memory":"2Gi"}},"sourceSecretName":"","strategy":{"docker":{"dockerfilePath":"./Dockerfile","pullSecrets":[]},"source":{"scripts":"https://raw.githubusercontent.com/janus-idp/redhat-backstage-build/add-s2i/.s2i/bin/"},"type":"Source"},"successfulBuildsHistoryLimit":5,"triggers":[{"type":"ConfigChange"},{"type":"ImageChange"}],"uri":"https://github.com/janus-idp/backstage-showcase.git"}` |
+| build.buildConfig.annotations | Additional annotations to apply to the BuildConfig | object | `{}` |
+| build.buildConfig.completionDeadlineSeconds | Build timeout in seconds. Defaults to 30 minutes | int | `1800` |
+| build.buildConfig.contextDir | Source repository context folder <br /> Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/creating-build-inputs.html#builds-source-code_creating-build-inputs | string | `""` |
+| build.buildConfig.failedBuildsHistoryLimit | Amount of failed builds to keep in history | int | `5` |
+| build.buildConfig.ref | Source repository reference <br /> Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/creating-build-inputs.html#builds-source-code_creating-build-inputs | string | `"main"` |
+| build.buildConfig.resources | Resource requests/limits <br /> Ref: https://kubernetes.io/docs/user-guide/compute-resources/ | object | `{"limits":{"cpu":"500m","memory":"2Gi"}}` |
+| build.buildConfig.sourceSecretName | Secrets to be used when cloning the source repository <br /> Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/creating-build-inputs.html#builds-adding-source-clone-secrets_creating-build-inputs | string | `""` |
+| build.buildConfig.strategy | Build strategy settings | object | `{"docker":{"dockerfilePath":"./Dockerfile","pullSecrets":[]},"source":{"scripts":"https://raw.githubusercontent.com/janus-idp/redhat-backstage-build/add-s2i/.s2i/bin/"},"type":"Source"}` |
+| build.buildConfig.strategy.docker | Docker build strategy: Use Buildah to build a container image from a Dockerfile | object | `{"dockerfilePath":"./Dockerfile","pullSecrets":[]}` |
+| build.buildConfig.strategy.docker.dockerfilePath | Path to dockerfile relative to contextDir <br /> Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/build-strategies.html#builds-strategy-dockerfile-path_build-strategies | string | `"./Dockerfile"` |
+| build.buildConfig.strategy.docker.pullSecrets | Pull secrets to be used for images referenced in Dockerfile <br /> Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/creating-build-inputs.html#builds-docker-credentials-private-registries_creating-build-inputs | list | `[]` |
+| build.buildConfig.strategy.source | Source-to-image build strategy | object | `{"scripts":"https://raw.githubusercontent.com/janus-idp/redhat-backstage-build/add-s2i/.s2i/bin/"}` |
+| build.buildConfig.strategy.source.scripts | Override S2I scripts by custom location. Defaults to Janus-IDP scripts that work for Backstage out of the box <br /> Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/build-strategies.html#builds-strategy-s2i-override-builder-image-scripts_build-strategies-docker | string | `"https://raw.githubusercontent.com/janus-idp/redhat-backstage-build/add-s2i/.s2i/bin/"` |
+| build.buildConfig.strategy.type | Build strategy selector. This chart currently supports either "Source" or "Docker" values. | string | `"Source"` |
+| build.buildConfig.successfulBuildsHistoryLimit | Amount of successful builds to keep in history | int | `5` |
+| build.buildConfig.triggers | Triggers that initiate a new build. <br /> Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/triggering-builds-build-hooks.html | list | `[{"type":"ConfigChange"},{"type":"ImageChange"}]` |
+| build.buildConfig.uri | Source repository URI <br /> Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/creating-build-inputs.html#builds-source-code_creating-build-inputs | string | `"https://github.com/janus-idp/backstage-showcase.git"` |
+| build.enabled | Enables creation of BuildConfig and ImageStream resources | bool | `false` |
+| build.imageStream | ImageStream specific values | object | `{"annotations":{}}` |
+| build.imageStream.annotations | Additional annotations to apply to the ImageStream | object | `{}` |
 | route | OpenShift Route parameters | object | `{"annotations":{},"enabled":true,"host":"","path":"/","tls":{"caCertificate":"","certificate":"","destinationCACertificate":"","enabled":true,"insecureEdgeTerminationPolicy":"Redirect","key":"","termination":"edge"},"wildcardPolicy":"None"}` |
 | route.annotations | Route specific annotations | object | `{}` |
 | route.enabled | Enable the creation of the route resource | bool | `true` |
@@ -210,3 +232,30 @@ route:
 global:
   host: backstage.apps.example.com
 ```
+
+### OpenShift Build
+
+In addition to providing a complete image for deployment, this feature allows user to refence a Backstage repository instead. This repository will be turned into an image in-cluster through OpenShift BuildConfig. In order to properly propagate the image to the Deployment, use following values as a baseline:
+
+```yaml
+upstream:
+  backstage:
+    image:
+      # Make the Deployment reference an image from local image registry in OpenShift
+      registry: ''
+      repository: '{{ .Release.Namespace }}/{{ include "common.names.fullname" . }}'
+
+    annotations:
+      # Enable rollouts when new image becomes available
+      image.openshift.io/triggers: |
+        [{"from":{"kind":"ImageStreamTag","name":"{{ include "common.names.fullname" . }}"},"fieldPath":"spec.template.spec.containers[0].image"}]
+
+    podAnnotations:
+      # Enables ImageStream lookup
+      alpha.image.policy.openshift.io/resolve-names: '*'
+
+build:
+  enabled: true
+```
+
+The process can be furtner customized through the `build` value in `values.yaml` file. For more details see [Values section](#values) above.

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -179,3 +179,30 @@ route:
 global:
   host: backstage.apps.example.com
 ```
+
+### OpenShift Build
+
+In addition to providing a complete image for deployment, this feature allows user to refence a Backstage repository instead. This repository will be turned into an image in-cluster through OpenShift BuildConfig. In order to properly propagate the image to the Deployment, use following values as a baseline:
+
+```yaml
+upstream:
+  backstage:
+    image:
+      # Make the Deployment reference an image from local image registry in OpenShift
+      registry: ''
+      repository: '{{"{{"}} .Release.Namespace {{"}}"}}/{{"{{"}} include "common.names.fullname" . {{"}}"}}'
+
+    annotations:
+      # Enable rollouts when new image becomes available
+      image.openshift.io/triggers: |
+        [{"from":{"kind":"ImageStreamTag","name":"{{"{{"}} include "common.names.fullname" . {{"}}"}}"},"fieldPath":"spec.template.spec.containers[0].image"}]
+
+    podAnnotations:
+      # Enables ImageStream lookup
+      alpha.image.policy.openshift.io/resolve-names: '*'
+
+build:
+  enabled: true
+```
+
+The process can be furtner customized through the `build` value in `values.yaml` file. For more details see [Values section](#values) above.

--- a/charts/backstage/templates/_helpers.tpl
+++ b/charts/backstage/templates/_helpers.tpl
@@ -1,0 +1,18 @@
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "janusIdp.renderImageBuildPullSecrets" -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.build.buildConfig) "context" $) -}}
+{{- end -}}
+
+
+{{/*
+Return the proper image name
+THIS IS AN OVERRIDE of upstream helper! 
+
+https://github.com/backstage/charts/blob/13a408cc070005a9960a5e2a3f6ebfdd8c77d8d2/charts/backstage/templates/_helpers.tpl#L4
+*/}}
+{{- define "backstage.image" -}}
+{{- $templatedImage := include "common.images.image" (dict "imageRoot" .Values.backstage.image "global" .Values.global) -}}
+{{ include "common.tplvalues.render" ( dict "value" $templatedImage "context" $ ) }}
+{{- end -}}

--- a/charts/backstage/templates/buildconfig.yaml
+++ b/charts/backstage/templates/buildconfig.yaml
@@ -1,0 +1,66 @@
+{{- if .Values.build.enabled }}
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: backstage
+    {{- if .Values.upstream.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.upstream.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.upstream.commonAnnotations .Values.build.buildConfig.annotations }}
+  annotations:
+    {{- if .Values.build.buildConfig.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.build.buildConfig.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.upstream.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.upstream.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  resources:
+    {{- include "common.tplvalues.render" ( dict "value" .Values.build.buildConfig.resources "context" $) | nindent 4 }}
+  failedBuildsHistoryLimit: {{ .Values.build.buildConfig.failedBuildsHistoryLimit }}
+  successfulBuildsHistoryLimit: {{ .Values.build.buildConfig.successfulBuildsHistoryLimit }}
+  output:
+    to:
+      kind: ImageStreamTag
+      name: {{ include "common.names.fullname" . }}
+      namespace: {{ .Release.Namespace | quote }}
+  runPolicy: Serial
+  source:
+    type: Git
+    git:
+      uri: {{ .Values.build.buildConfig.uri }}
+      ref: {{ .Values.build.buildConfig.ref }}
+    {{- if .Values.build.buildConfig.contextDir }}
+    contextDir: {{ .Values.build.buildConfig.contextDir }}
+    {{- end }}
+    {{- if .Values.build.buildConfig.sourceSecretName }}
+    sourceSecret:
+      name: {{ .Values.build.buildConfig.sourceSecretName }}
+    {{- end }}
+  strategy:
+    {{- if not (has .Values.build.buildConfig.strategy.type (list "Docker" "Source")) }}
+    {{- fail "value 'build.buildConfig.type' must be either 'Docker' or 'Source'" }}
+    {{- end }}
+    {{- if eq .Values.build.buildConfig.strategy.type "Docker" }}
+    type: Docker
+    dockerStrategy:
+      dockerfilePath: {{ .Values.build.buildConfig.strategy.docker.dockerfilePath }}
+      {{- include "janusIdp.renderImageBuildPullSecrets" . | nindent 6 }}
+    {{- else }}
+    type: Source
+    sourceStrategy:
+      from:
+        kind: ImageStreamTag
+        name: "nodejs:latest"
+        namespace: openshift
+      {{- if  .Values.build.buildConfig.strategy.source.scripts }}
+      scripts: {{ .Values.build.buildConfig.strategy.source.scripts }}
+      {{- end }}
+    {{- end }}
+  triggers:
+    {{- include "common.tplvalues.render" ( dict "value" .Values.build.buildConfig.triggers "context" $ ) | nindent 4 }}
+{{- end }}

--- a/charts/backstage/templates/imagestream.yaml
+++ b/charts/backstage/templates/imagestream.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.build.enabled }}
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: backstage
+    {{- if .Values.upstream.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.upstream.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.upstream.commonAnnotations .Values.build.imageStream.annotations }}
+  annotations:
+    {{- if .Values.build.imageStream.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.build.imageStream.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.upstream.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.upstream.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  lookupPolicy:
+    local: true
+{{- end }}

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -107,6 +107,194 @@
                     }
                 }
             }
+        },
+        "build": {
+            "title": "Build Backstage image in-cluster",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "title": "Enables creation of BuildConfig and ImageStream resources.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "imageStream": {
+                    "title": "ImageStream specific values",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "annotations": {
+                            "title": "Additional annotations to apply to the ImageStream",
+                            "type": "object",
+                            "default": {}
+                        }
+                    }
+                },
+                "buildConfig": {
+                    "title": "BuildConfig specific values",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "annotations": {
+                            "title": "Additional annotations to apply to the BuildConfig",
+                            "type": "object",
+                            "default": {}
+                        },
+                        "uri": {
+                            "title": "Source repository URI",
+                            "description": "Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/creating-build-inputs.html#builds-source-code_creating-build-inputs",
+                            "type": "string",
+                            "default": "https://github.com/janus-idp/backstage-showcase.git"
+                        },
+                        "ref": {
+                            "title": "Source repository reference",
+                            "description": "Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/creating-build-inputs.html#builds-source-code_creating-build-inputs",
+                            "type": "string",
+                            "default": "main",
+                            "examples": [
+                                "main",
+                                "HEAD",
+                                "feature-branch",
+                                "1a410e"
+                            ]
+                        },
+                        "contextDir": {
+                            "title": "Source repository context folder",
+                            "description": "Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/creating-build-inputs.html#builds-source-code_creating-build-inputs",
+                            "type": "string",
+                            "default": "",
+                            "examples": [
+                                "/",
+                                "folder/within/repository"
+                            ]
+                        },
+                        "sourceSecretName": {
+                            "title": "Secrets to be used when cloning the source repository",
+                            "description": "Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/creating-build-inputs.html#builds-adding-source-clone-secrets_creating-build-inputs",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "failedBuildsHistoryLimit": {
+                            "title": "Amount of failed builds to keep in history",
+                            "type": "integer",
+                            "default": 5,
+                            "minimum": 0
+                        },
+                        "successfulBuildsHistoryLimit": {
+                            "title": "Amount of successful builds to keep in history",
+                            "type": "integer",
+                            "default": 5,
+                            "minimum": 0
+                        },
+                        "completionDeadlineSeconds": {
+                            "title": "Build timeout in seconds",
+                            "description": "Defaults to 30 minutes",
+                            "type": "integer",
+                            "default": 1800,
+                            "minimum": 0
+                        },
+                        "resources": {
+                            "title": "Resource requests/limits",
+                            "description": "Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-requests-and-limits-of-pod-and-container",
+                            "$ref": "https://kubernetesjsonschema.dev/master/_definitions.json#/definitions/io.k8s.api.core.v1.ResourceRequirements",
+                            "default": {
+                                "limits": {
+                                    "cpu": "500m",
+                                    "memory": "2Gi"
+                                }
+                            },
+                            "examples": [
+                                {
+                                    "limits": {
+                                        "memory": "1Gi",
+                                        "cpu": "1000m"
+                                    },
+                                    "requests": {
+                                        "memory": "250Mi",
+                                        "cpu": "100m"
+                                    }
+                                }
+                            ]
+                        },
+                        "strategy": {
+                            "title": "Build strategy settings",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "type": {
+                                    "title": "Build strategy selector",
+                                    "type": "string",
+                                    "default": "Source",
+                                    "enum": [
+                                        "Source",
+                                        "Docker"
+                                    ]
+                                },
+                                "source": {
+                                    "title": "Source-to-image build strategy",
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "scripts": {
+                                            "title": "Override S2I scripts by custom location",
+                                            "description": "Defaults to Janus-IDP scripts that work for Backstage out of the box, ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/build-strategies.html#builds-strategy-s2i-override-builder-image-scripts_build-strategies-docker",
+                                            "default": "https://raw.githubusercontent.com/janus-idp/redhat-backstage-build/add-s2i/.s2i/bin/"
+                                        }
+                                    }
+                                },
+                                "docker": {
+                                    "title": "Docker build strategy",
+                                    "description": "Use Buildah to build a container image from a Dockerfile",
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "pullSecrets": {
+                                            "title": "Pull secrets to be used for images referenced in Dockerfile",
+                                            "description": "Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/creating-build-inputs.html#builds-docker-credentials-private-registries_creating-build-inputs",
+                                            "type": "array",
+                                            "default": []
+                                        },
+                                        "dockerfilePath": {
+                                            "title": "Path to dockerfile relative to contextDir",
+                                            "description": "Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/build-strategies.html#builds-strategy-dockerfile-path_build-strategies",
+                                            "default": "./Dockerfile"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "triggers": {
+                            "title": "Triggers that initiate a new build",
+                            "description": "Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/triggering-builds-build-hooks.html",
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "ConfigChange",
+                                            "ImageChange",
+                                            "Generic",
+                                            "Bitbucket",
+                                            "GitHub",
+                                            "GitLab"
+                                        ]
+                                    }
+                                }
+                            },
+                            "default": [
+                                {
+                                    "type": "ConfigChange"
+                                },
+                                {
+                                    "type": "ImageChange"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -108,3 +108,83 @@ route:
     # --  Indicates the desired behavior for insecure connections to a route.
     # <br /> While each router may make its own decisions on which ports to expose, this is normally port 80. The only valid values are None, Redirect, or empty for disabled.
     insecureEdgeTerminationPolicy: "Redirect"
+
+
+# -- Build Backstage image in-cluster
+build:
+
+  # -- Enables creation of BuildConfig and ImageStream resources
+  enabled: false
+
+  # -- ImageStream specific values
+  imageStream:
+
+    # -- Additional annotations to apply to the ImageStream
+    annotations: {}
+
+  # --  BuildConfig specific values
+  buildConfig:
+
+    # -- Additional annotations to apply to the BuildConfig
+    annotations: {}
+
+    # -- Source repository URI
+    # <br /> Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/creating-build-inputs.html#builds-source-code_creating-build-inputs
+    uri: "https://github.com/janus-idp/backstage-showcase.git"
+
+    # -- Source repository reference
+    # <br /> Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/creating-build-inputs.html#builds-source-code_creating-build-inputs
+    ref: "main"
+
+    # -- Source repository context folder
+    # <br /> Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/creating-build-inputs.html#builds-source-code_creating-build-inputs
+    contextDir: ""
+
+    # -- Secrets to be used when cloning the source repository
+    # <br /> Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/creating-build-inputs.html#builds-adding-source-clone-secrets_creating-build-inputs
+    sourceSecretName: ""
+
+    # -- Amount of failed builds to keep in history
+    failedBuildsHistoryLimit: 5
+
+    # -- Amount of successful builds to keep in history
+    successfulBuildsHistoryLimit: 5
+
+    # -- Build timeout in seconds. Defaults to 30 minutes
+    completionDeadlineSeconds: 1800
+
+    # -- Resource requests/limits
+    # <br /> Ref: https://kubernetes.io/docs/user-guide/compute-resources/
+    resources:
+      limits:
+        cpu: "500m"
+        memory: "2Gi"
+
+    # -- Build strategy settings
+    strategy:
+
+      # -- Build strategy selector. This chart currently supports either "Source" or "Docker" values.
+      type: "Source"
+
+      # -- Source-to-image build strategy
+      source:
+
+        # -- Override S2I scripts by custom location. Defaults to Janus-IDP scripts that work for Backstage out of the box
+        # <br /> Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/build-strategies.html#builds-strategy-s2i-override-builder-image-scripts_build-strategies-docker
+        scripts: "https://raw.githubusercontent.com/janus-idp/redhat-backstage-build/add-s2i/.s2i/bin/"
+
+      # -- Docker build strategy: Use Buildah to build a container image from a Dockerfile
+      docker:
+        # -- Pull secrets to be used for images referenced in Dockerfile
+        # <br /> Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/creating-build-inputs.html#builds-docker-credentials-private-registries_creating-build-inputs
+        pullSecrets: []
+
+        # -- Path to dockerfile relative to contextDir
+        # <br /> Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/build-strategies.html#builds-strategy-dockerfile-path_build-strategies
+        dockerfilePath: "./Dockerfile"
+
+    # -- Triggers that initiate a new build.
+    # <br /> Ref: https://docs.openshift.com/container-platform/4.12/cicd/builds/triggering-builds-build-hooks.html
+    triggers:
+      - type: ConfigChange
+      - type: ImageChange


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves redhat-developer/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

Allow users to build images in local cluster instead of using a prepared image. Options are described in the README, along with a `values.yaml` sample.

## Existing or Associated Issue(s)

Requires: https://github.com/janus-idp/redhat-backstage-build/pull/3 and https://github.com/backstage/charts/pull/78


## Additional Information


 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
