### PR TITLE
chore: update deps and add Chart.yaml metadata

### DIFF
--- a/charts/backstage/Chart.lock
+++ b/charts/backstage/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.17.1
+  version: 2.2.4
 - name: backstage
   repository: https://backstage.github.io/charts
-  version: 0.18.0
-digest: sha256:856ccea6ad70c2d20936a39c97a68c3d96f5451b2cf277ebbc52e8f9695ee70f
-generated: "2023-03-13T15:03:48.826673+01:00"
+  version: 0.21.1
+digest: sha256:b0f2c6e7dd5f3ed8b06f748f3778b7441ca53310d2348037715cdc029b882e14
+generated: "2023-04-28T10:57:55.832512+02:00"

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -1,29 +1,44 @@
+annotations:
+  artifacthub.io/category: integration-delivery
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: support
+      url: https://github.com/janus-idp/helm-backstage/issues
+    - name: Chart Source
+      url: https://github.com/janus-idp/helm-backstage
+    - name: Default Image Source
+      url: https://github.com/janus-idp/redhat-backstage-build
+  charts.openshift.io/name: Backstage
+  charts.openshift.io/provider: Janus-IDP
+  charts.openshift.io/supportURL: https://github.com/janus-idp/helm-backstage/issues
 apiVersion: v2
-name: backstage
 description: A Helm chart for deploying a Backstage application
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
-type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-# Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
-
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
   - name: backstage
     repository: https://backstage.github.io/charts
-    version: ">=0.18.0"
+    version: ">=0.21.1"
     alias: upstream
+home: https://janus-idp.io
+icon: https://avatars.githubusercontent.com/u/117844786
+keywords:
+- backstage
+- idp
+- janus-idp
+maintainers:
+  - name: Janus-IDP
+    url: https://janus-idp.io
+name: backstage
+type: application
+sources:
+- https://github.com/janus-idp/helm-backstage
+- https://github.com/janus-idp/redhat-backstage-build
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.1

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,9 +1,22 @@
 
 # Janus-IDP Backstage Helm Chart
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
+
+**Homepage:** <https://janus-idp.io>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Janus-IDP |  | <https://janus-idp.io> |
+
+## Source Code
+
+* <https://github.com/janus-idp/helm-backstage>
+* <https://github.com/janus-idp/redhat-backstage-build>
 
 ---
 
@@ -81,8 +94,8 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://backstage.github.io/charts | upstream(backstage) | >=0.18.0 |
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://backstage.github.io/charts | upstream(backstage) | >=0.21.1 |
+| https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values
 

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -1,14 +1,112 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "http://example.com/example.json",
     "type": "object",
-    "default": {},
     "title": "Root Schema",
     "properties": {
         "upstream": {
+            "title": "Upstream Backstage chart schema.",
             "type": "object",
-            "default": {},
-            "title": "Upstream Backstage chart schema"
+            "default": {
+                "backstage": {
+                    "image": {
+                        "registry": "quay.io",
+                        "repository": "janus-idp/redhat-backstage-build",
+                        "tag": "latest"
+                    }
+                }
+            }
+        },
+        "route": {
+            "title": "OpenShift Route parameters.",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "annotations": {
+                    "title": "Route specific annotations.",
+                    "type":  "object",
+                    "default": {}
+                },
+                "enabled": {
+                    "title": "Enable the creation of the route resource.",
+                    "type": "boolean",
+                    "default": false
+                },
+                "host": {
+                    "title": "Set the host attribute to a custom value.",
+                    "type": "string",
+                    "default": "",
+                    "examples": [
+                        "https://bakstage.example.com"
+                    ]
+                },
+                "path": {
+                    "title": "Path that the router watches for, to route traffic for to the service.",
+                    "type": "string",
+                    "default": "/"
+                },
+                "wildcardPolicy": {
+                    "title": "Wildcard policy if any for the route.",
+                    "type": "string",
+                    "default": "None",
+                    "enum": [
+                        "None",
+                        "Subdomain"
+                    ]
+                },
+                "tls": {
+                    "title": "Route TLS parameters.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "title": "Enable TLS configuration for the host defined at `route.host` parameter.",
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "termination": {
+                            "title": "Specify TLS termination.",
+                            "type": "string",
+                            "default": "edge",
+                            "enum": [
+                                "edge",
+                                "reencrypt",
+                                "passthrough"
+                            ]
+                        },
+                        "certificate": {
+                            "title": "Certificate contents.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "key": {
+                            "title": "Key file contents.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "caCertificate": {
+                            "title": "Cert authority certificate contents.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "destinationCACertificate": {
+                            "title": "Contents of the ca certificate of the final destination.",
+                            "type": "string",
+                            "default": ""
+                        },
+                        "insecureEdgeTerminationPolicy": {
+                            "title": "Indicates the desired behavior for insecure connections to a route.",
+                            "type": "string",
+                            "default": "Redirect",
+                            "enum": [
+                                "Redirect",
+                                "None",
+                                ""
+                            ]
+                        }
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves janus-idp/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

Update `backstage` chart dependency. Notable changes:
- adds/fixes support for `extraDeploy`

Update `bitnami-common` chart dependency. Mayor release change - affected feature (adds support for `image.digest` in addition to `image.tag`) is not used in this chart.

Adds additional metadata to better support ArtifactHub publishing and OpenShift Helm catalog publishing.

## Existing or Associated Issue(s)

N/A

## Additional Information

N/A

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [ ] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
