### PR TITLE
chore: set required kubeVersion because of Ingress resource

### DIFF
--- a/charts/backstage/Chart.lock
+++ b/charts/backstage/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.2.4
+  version: 2.2.5
 - name: backstage
   repository: https://backstage.github.io/charts
-  version: 0.21.1
-digest: sha256:b0f2c6e7dd5f3ed8b06f748f3778b7441ca53310d2348037715cdc029b882e14
-generated: "2023-04-28T10:57:55.832512+02:00"
+  version: 0.22.3
+digest: sha256:34bc49e9edf6bdf26eae23e40fc6f62a8c2fe0c41f8573e55531f169b7b19d35
+generated: "2023-05-09T15:09:31.191794+02:00"

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -21,7 +21,7 @@ dependencies:
     version: 2.x.x
   - name: backstage
     repository: https://backstage.github.io/charts
-    version: ">=0.21.1"
+    version: ">=0.22.3"
     alias: upstream
 home: https://janus-idp.io
 icon: https://avatars.githubusercontent.com/u/117844786
@@ -29,6 +29,7 @@ keywords:
 - backstage
 - idp
 - janus-idp
+kubeVersion: ">= 1.19.0-0"
 maintainers:
   - name: Janus-IDP
     url: https://janus-idp.io
@@ -41,4 +42,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.0.2

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -1,7 +1,7 @@
 
 # Janus-IDP Backstage Helm Chart
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
 
@@ -92,9 +92,11 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Requirements
 
+Kubernetes: `>= 1.19.0-0`
+
 | Repository | Name | Version |
 |------------|------|---------|
-| https://backstage.github.io/charts | upstream(backstage) | >=0.21.1 |
+| https://backstage.github.io/charts | upstream(backstage) | >=0.22.3 |
 | https://charts.bitnami.com/bitnami | common | 2.x.x |
 
 ## Values


### PR DESCRIPTION
## Description of the change

The latest kubernetes version restriction I've found is that the upstream chart uses `Ingress` resource which went GA in `1.19.0`.

## Existing or Associated Issue(s)

N/A

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
