### PR TITLE
chore: verify artifacthub publisher

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,12 @@
+# Artifact Hub repository metadata file
+#
+# Some settings like the verified publisher flag or the ignored packages won't
+# be applied until the next time the repository is processed. Please keep in
+# mind that the repository won't be processed if it has not changed since the
+# last time it was processed. Depending on the repository kind, this is checked
+# in a different way. For Helm http based repositories, we consider it has
+# changed if the `index.yaml` file changes. For git based repositories, it does
+# when the hash of the last commit in the branch you set up changes. This does
+# NOT apply to ownership claim operations, which are processed immediately.
+#
+repositoryID: 23c796cc-343d-4b00-9cae-43b00dc5caa4


### PR DESCRIPTION
Adds a `repositoryID` claim, that should allow us to become Verified publisher at ArtifactHub

https://artifacthub.io/docs/topics/repositories/#verified-publisher