### PR TITLE
feat: switch to Showcase as default image

### DIFF
--- a/charts/backstage/Chart.lock
+++ b/charts/backstage/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.2.5
+  version: 2.4.0
 - name: backstage
   repository: https://backstage.github.io/charts
-  version: 0.22.3
-digest: sha256:34bc49e9edf6bdf26eae23e40fc6f62a8c2fe0c41f8573e55531f169b7b19d35
-generated: "2023-05-09T15:09:31.191794+02:00"
+  version: 1.0.0
+digest: sha256:73bf762f0c02f16479314fcffeafbf683f2fc758ac2aea5113a98b6618fb0b15
+generated: "2023-05-19T17:08:32.733557+02:00"

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -7,7 +7,7 @@ annotations:
     - name: Chart Source
       url: https://github.com/janus-idp/helm-backstage
     - name: Default Image Source
-      url: https://github.com/janus-idp/redhat-backstage-build
+      url: https://github.com/janus-idp/backstage-showcase
   charts.openshift.io/name: Backstage
   charts.openshift.io/provider: Janus-IDP
   charts.openshift.io/supportURL: https://github.com/janus-idp/helm-backstage/issues
@@ -21,7 +21,7 @@ dependencies:
     version: 2.x.x
   - name: backstage
     repository: https://backstage.github.io/charts
-    version: ">=0.22.3"
+    version: "1.x.x"
     alias: upstream
 home: https://janus-idp.io
 icon: https://avatars.githubusercontent.com/u/117844786
@@ -37,9 +37,9 @@ name: backstage
 type: application
 sources:
 - https://github.com/janus-idp/helm-backstage
-- https://github.com/janus-idp/redhat-backstage-build
+- https://github.com/janus-idp/backstage-showcase
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 2.0.0

--- a/charts/backstage/README.md.gotmpl
+++ b/charts/backstage/README.md.gotmpl
@@ -62,7 +62,31 @@ The following command can be used to add the chart repository:
 helm repo add janus-idp https://janus-idp.github.io/helm-backstage
 ```
 
-Once the chart has been added, install one of the available charts:
+Once the chart has been added, install this chart. However before doing so, please review the default `values.yaml` and adjust as needed.
+
+- To get proper connection between frontend and backend of Backstage please update the `apps.example.com` to match your cluster host:
+
+   ```yaml
+   upstream:
+     backstage:
+       appConfig:
+         app:
+           baseUrl: 'https://{{"{{"}}- print .Release.Name "-" .Release.Namespace -{{"}}"}}.apps.example.com'
+         backend:
+           baseUrl: 'https://{{"{{"}}- print .Release.Name "-" .Release.Namespace -{{"}}"}}.apps.example.com'
+           cors:
+             origin: 'https://{{"{{"}}- print .Release.Name "-" .Release.Namespace -{{"}}"}}.apps.example.com'
+   ```
+
+- If your cluster doesn't provide PVCs, you should disable PostgreSQL persistence via:
+
+   ```yaml
+   upstream:
+     postgresql:
+       primary:
+         persistence:
+           enabled: false
+   ```
 
 ```console
 helm upgrade -i <release_name> janus-idp/backstage
@@ -94,15 +118,38 @@ The command removes all the Kubernetes components associated with the chart and 
 
 {{ template "chart.valuesSection" . }}
 
+## Opinionated Backstage deployment
+
+This chart defaults to an opinionated deployment of Backstage that provides user with a usable Backstage instance out of the box.
+
+Features enabled by the default chart configuration:
+
+1. Uses [janus-idp/backstage-showcase](https://github.com/janus-idp/backstage-showcase/) that pre-loads a lot of useful plugins and features
+2. Exposes a `Route` for easy access to the instance
+3. Enables OpenShift-compatible PostgreSQL database storage
+
+For additional instance features please consuls [documentation for `janus-idp/backstage-showcase`](https://github.com/janus-idp/backstage-showcase/).
+
+Additional features can be enabled by extending the default configuration at:
+
+```yaml
+upstream:
+  backstage:
+    appConfig:
+      # Inline app-config.yaml for the instance
+    extraEnvVars:
+      # Additional environment variables
+```
+
 ## Features
 
-This charts defaults to using the Janus-IDP built image for backstage that is OpenShift compatible:
+This charts defaults to using the Janus-IDP Backstage Showcase image that is OpenShift compatible:
 
 ```
-quay.io/janus-idp/redhat-backstage-build:latest
+quay.io/janus-idp/backstage-showcase:latest
 ```
 
-Additionally this chart enhances the upstream Backstage chart with following OpenShift-specific features.
+Additionally this chart enhances the upstream Backstage chart with following OpenShift-specific features:
 
 ### OpenShift Routes
 

--- a/charts/backstage/ci/default-values.yaml
+++ b/charts/backstage/ci/default-values.yaml
@@ -1,0 +1,8 @@
+# Workaround for kind cluster in CI which has no Routes and no PVCs
+route:
+  enabled: false
+upstream:
+  postgresql:
+    primary:
+      persistence:
+        enabled: false

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -4,8 +4,59 @@ upstream:
   backstage:
     image:
       registry: quay.io
-      repository: janus-idp/redhat-backstage-build
+      repository: janus-idp/backstage-showcase
       tag: latest
+    command: []
+    # FIXME (tumido): USE POSTGRES_PASSWORD and POSTGRES_USER instead of POSTGRES_ADMIN_PASSWORD
+    # This is a hack. In {fedora,rhel}/postgresql images, regular user is forbidden
+    # from creating DBs in runtime. A single DB can be created ahead of time via
+    # POSTGRESQL_DATABASE env variable (in this case via
+    # upstream.postgresql.primary.extraEnvVars value), but this doesn't allow us to
+    # create multiple DBs. Since Backstage requires by default 5 different DBs, we
+    # can't accommodate that properly.
+    appConfig:
+      app:
+        # Please update to match host.
+        baseUrl: 'https://{{- print .Release.Name "-" .Release.Namespace -}}.apps.example.com'
+      backend:
+        baseUrl: 'https://{{- print .Release.Name "-" .Release.Namespace -}}.apps.example.com'
+        cors:
+          origin: 'https://{{- print .Release.Name "-" .Release.Namespace -}}.apps.example.com'
+        database:
+          connection:
+            password: ${POSTGRESQL_ADMIN_PASSWORD}
+            user: postgres
+    extraEnvVars:
+    - name: POSTGRESQL_ADMIN_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          key: postgres-password
+          name: "{{ .Release.Name }}-postgresql"
+
+  postgresql:
+    enabled: true
+    postgresqlDataDir: /var/lib/pgsql/data/userdata
+    image:
+      registry: quay.io
+      repository: fedora/postgresql-15
+      tag: latest
+    primary:
+      securityContext:
+        enabled: false
+      podSecurityContext:
+        enabled: false
+      containerSecurityContext:
+        enabled: false
+      persistence:
+        enabled: true
+        size: 1Gi
+        mountPath: /var/lib/pgsql/data
+      extraEnvVars:
+      - name: POSTGRESQL_ADMIN_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            key: postgres-password
+            name: "{{ .Release.Name }}-postgresql"
 
 
 # -- OpenShift Route parameters
@@ -15,7 +66,7 @@ route:
   annotations: {}
 
   # -- Enable the creation of the route resource
-  enabled: false
+  enabled: true
 
   # -- Set the host attribute to a custom value. If not set, OpenShift will generate it, please make sure to match your baseUrl
   host: ""
@@ -31,7 +82,7 @@ route:
   tls:
 
     # -- Enable TLS configuration for the host defined at `route.host` parameter
-    enabled: false
+    enabled: true
 
     # -- Specify TLS termination.
     termination: "edge"


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves janus-idp/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

Switches the default, the out-of-the-box experience to use `backstage-showcase`. This requires enabling PostgreSQL as well as ingress

## Existing or Associated Issue(s)

Resolves: https://github.com/janus-idp/book/issues/14

Depends on:
- [x] https://github.com/backstage/charts/pull/105
- [x] https://github.com/janus-idp/backstage-showcase/pull/264

## Additional Information

This PR should is not entirely safe. Due to internal limitations of `{fedora,rhel,centos}/postgresql` images we're unable to fully prepare the DB for our runtime using the upstream chart.

These images allow us to create a secure database user via `POSTGRESQL_USER` environment variable and create 1 single `POSTGRESQL_DATABASE` for it. However Backstage require at least 5 different databases to be created. I'm unable to achieve this with the native means the chart/image offers me. Therefore I set a fallback to using `postgres` admin user for the backstage instance. I know it's not ideal.

I've noticed this problem was cheated (aka worked around) a bit in our blog posts by telling users to use the default `bitnami/postgresql` images first (to do the database init and setup) and switch to `fedora/postgresql` later on.

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [helm-docs](https://github.com/norwoodj/helm-docs) utility can be used to generate the necessary content. Use `helm-docs --dry-run` to preview the content.
- [x] JSON Schema generated.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
