### PR TITLE
chore(renovate): autocommit pre-commit changes

### DIFF
--- a/.github/workflows/update-renovate-prs.yml
+++ b/.github/workflows/update-renovate-prs.yml
@@ -1,0 +1,46 @@
+name: Update renovate PRs
+
+on:
+  push:
+    branches:
+      - 'renovate/**'
+
+jobs:
+  check-metadata:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      id-token: write
+
+    env:
+      GO111MODULE: on
+    steps:
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: actions/setup-python@bd6b4b6205c4dbad673328db7b31b7fab9e241c0 # v4
+        with:
+          python-version: 3.7
+
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4
+        with:
+          go-version: ^1
+
+      - name: Setup helm-docs
+        run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
+
+      - name: Run pre-commit
+        uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # renovate: tag=v3.0.0
+        continue-on-error: true
+
+      - name: Setup Gitsign
+        uses: chainguard-dev/actions/setup-gitsign@main
+
+      - name: Commit pre-commit changes
+        uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4
+        with:
+          commit_message: Apply pre-commit changes
+          commit_options: '-s'


### PR DESCRIPTION
## Description of the change

We want renovate to update our dependencies. However any dependency change means need to regenerate metadata files via `pre-commit`. This workflow should allow that.

## Existing or Associated Issue(s)

https://github.com/janus-idp/helm-backstage/issues/81

## Additional Information


## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [x] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
