### PR TITLE
chore(ci): hub cli was removed from runner - use gh cli instead

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Checkout Pull Request
         if: steps.command.outputs.command-name
-        run: hub pr checkout ${{ github.event.issue.number }}
+        run: gh pr checkout ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves janus-idp/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

`/bump` command started failing due to:

```
Run hub pr checkout 120
  hub pr checkout 1[2](https://github.com/janus-idp/helm-backstage/actions/runs/6480161337/job/17595122977?pr=120#step:9:2)0
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/[3](https://github.com/janus-idp/helm-backstage/actions/runs/6480161337/job/17595122977?pr=120#step:9:3).7.17/x6[4](https://github.com/janus-idp/helm-backstage/actions/runs/6480161337/job/17595122977?pr=120#step:9:4)
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.7.17/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.7.17/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.7.17/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.7.17/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.7.17/x64/lib
    GITHUB_TOKEN: ***
/home/runner/work/_temp/4[5](https://github.com/janus-idp/helm-backstage/actions/runs/6480161337/job/17595122977?pr=120#step:9:5)f3[6](https://github.com/janus-idp/helm-backstage/actions/runs/6480161337/job/17595122977?pr=120#step:9:6)8e8-6349-446d-8f20-5ec85[7](https://github.com/janus-idp/helm-backstage/actions/runs/6480161337/job/17595122977?pr=120#step:9:7)bd[8](https://github.com/janus-idp/helm-backstage/actions/runs/6480161337/job/17595122977?pr=120#step:9:8)c8b.sh: line 1: hub: command not found
Error: Process completed with exit code [12](https://github.com/janus-idp/helm-backstage/actions/runs/6480161337/job/17595122977?pr=120#step:9:13)7.
```
https://github.com/janus-idp/helm-backstage/actions/runs/6480161337/job/17595122977?pr=120

According to https://github.com/actions/runner-images/pull/8437 the `hub` cli was removed from the latest Ubuntu runner.

This PR implements a straightforward fix - `s/hub/gh`. To use https://cli.github.com/ instead of https://hub.github.com/

## Existing or Associated Issue(s)

N/A

## Additional Information

N/A

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [x] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
