### PR TITLE
feat(auth): support service to service backend auth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Lint Charts
+name: Test Charts
 
 on:
   pull_request:
@@ -8,6 +8,7 @@ on:
 
 jobs:
   check-metadata:
+    name: Lint Metadata
     runs-on: ubuntu-latest
     env:
       GO111MODULE: on
@@ -30,7 +31,8 @@ jobs:
         uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507 # renovate: tag=v3.0.0
         with:
           extra_args: --show-diff-on-failure
-  test:
+  test-latest:
+    name: Test Latest Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -69,6 +71,42 @@ jobs:
       - name: Run chart-testing (latest)
         # test with latest stable backstage-showcase release
         run: ct install --config ct-install.yaml --helm-extra-set-args="--set=upstream.backstage.image.tag=latest"
+  test-next:
+    name: Test Next Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # renovate: tag=v3.5
+        with:
+          version: v3.10.0
+
+      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@b43128a8b25298e1e7b043b78ea6613844e079b1 # v2.6.0
+
+      - name: "Add NGINX Ingress and Bitnami Repository"
+        run: |
+          helm repo add ingress-nginx "https://kubernetes.github.io/ingress-nginx"
+          helm repo add bitnami "https://charts.bitnami.com/bitnami"
+          helm repo add backstage https://backstage.github.io/charts
+          helm repo update
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config ct.yaml
+
+      - name: Create KIND Cluster
+        uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
+
+      - name: Install Ingress Controller
+        run: "helm install ingress-nginx/ingress-nginx --generate-name --set controller.service.type='NodePort' --set controller.admissionWebhooks.enabled=false"
 
       - name: Run chart-testing (next)
         # test with the next backstage-showcase version (main branch)

--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -41,4 +41,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.9.0
+version: 2.10.0

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Janus-IDP Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/janus-idp&style=flat-square)](https://artifacthub.io/packages/search?repo=janus-idp)
-![Version: 2.9.0](https://img.shields.io/badge/Version-2.9.0-informational?style=flat-square)
+![Version: 2.10.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application
@@ -128,6 +128,11 @@ Kubernetes: `>= 1.19.0-0`
 
 | Key | Description | Type | Default |
 |-----|-------------|------|---------|
+| global.auth | Enable service authentication within Backstage instance | object | `{"backend":{"enabled":true,"existingSecret":"","value":""}}` |
+| global.auth.backend | Backend service to service authentication <br /> Ref: https://backstage.io/docs/auth/service-to-service-auth/ | object | `{"enabled":true,"existingSecret":"","value":""}` |
+| global.auth.backend.enabled | Enable backend service to service authentication, unless configured otherwise it generates a secret value | bool | `true` |
+| global.auth.backend.existingSecret | Instead of generating a secret value, refer to existing secret | string | `""` |
+| global.auth.backend.value | Instead of generating a secret value, use fo;lowing value | string | `""` |
 | global.clusterRouterBase | Shorthand for users who do not want to specify a custom HOSTNAME. Used ONLY with the DEFAULT upstream.backstage.appConfig value and with OCP Route enabled. | string | `"apps.example.com"` |
 | global.dynamic.includes | Array of YAML files listing dynamic plugins to include with those listed in the `plugins` field. Relative paths are resolved from the working directory of the initContainer that will install the plugins (`/opt/app-root/src`). | list | `["dynamic-plugins.default.yaml"]` |
 | global.dynamic.includes[0] | List of dynamic plugins included inside the `janus-idp/backstage-showcase` container image, some of which are disabled by default. This file ONLY works with the `janus-idp/backstage-showcase` container image. | string | `"dynamic-plugins.default.yaml"` |

--- a/charts/backstage/ci/default-values.yaml
+++ b/charts/backstage/ci/default-values.yaml
@@ -6,9 +6,3 @@ upstream:
     primary:
       persistence:
         enabled: false
-  backstage:
-    appConfig:
-      backend:
-        auth:
-          keys:
-            - secret: sEKIT4CwJ4MwVLzen5SFL6fJmwOPB2sl

--- a/charts/backstage/templates/_helpers.tpl
+++ b/charts/backstage/templates/_helpers.tpl
@@ -10,3 +10,14 @@ Returns custom hostname
         {{ fail "Unable to generate hostname" }}
     {{- end -}}
 {{- end -}}
+
+{{/*
+Returns a secret name for service to service auth
+*/}}
+{{- define "janus-idp.backend-secret-name" -}}
+    {{- if .Values.global.auth.backend.existingSecret -}}
+        {{- .Values.global.auth.backend.existingSecret -}}
+    {{- else -}}
+        {{- include "common.names.fullname" . -}}-auth
+    {{- end -}}
+{{- end -}}

--- a/charts/backstage/templates/secrets.yaml
+++ b/charts/backstage/templates/secrets.yaml
@@ -1,0 +1,19 @@
+{{- if and (not .Values.global.auth.backend.existingSecret) .Values.global.auth.backend.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.names.fullname" . }}-auth
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: backstage
+    {{- if .Values.upstream.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.upstream.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.upstream.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.upstream.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+type: Opaque
+data:
+  backend-secret: {{ (ternary  (randAlphaNum 24 ) .Values.global.auth.backend.value (empty .Values.global.auth.backend.value)) | b64enc | quote }}
+{{- end }}

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -3,6 +3,35 @@
     "properties": {
         "global": {
             "properties": {
+                "auth": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "backend": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "enabled": {
+                                    "default": true,
+                                    "title": "Enable backend service to service authentication, unless configured otherwise it generates a secret value",
+                                    "type": "boolean"
+                                },
+                                "existingSecret": {
+                                    "default": "",
+                                    "title": "Instead of generating a secret value, refer to existing secret",
+                                    "type": "string"
+                                },
+                                "value": {
+                                    "default": "",
+                                    "title": "Instead of generating a secret value, use fo;lowing value",
+                                    "type": "string"
+                                }
+                            },
+                            "title": "Backend service to service authentication",
+                            "type": "object"
+                        }
+                    },
+                    "title": "Enable service authentication within Backstage instance",
+                    "type": "object"
+                },
                 "clusterRouterBase": {
                     "default": "apps.example.com",
                     "title": "Shorthand for users who do not want to specify a custom HOSTNAME. Used ONLY with the DEFAULT upstream.backstage.appConfig value and with OCP Route enabled.",

--- a/charts/backstage/values.schema.tmpl.json
+++ b/charts/backstage/values.schema.tmpl.json
@@ -67,6 +67,35 @@
                             "default": []
                         }
                     }
+                },
+                "auth": {
+                    "title": "Enable service authentication within Backstage instance",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "backend": {
+                            "title": "Backend service to service authentication",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "enabled": {
+                                    "title": "Enable backend service to service authentication, unless configured otherwise it generates a secret value",
+                                    "type": "boolean",
+                                    "default": true
+                                },
+                                "existingSecret": {
+                                    "title": "Instead of generating a secret value, refer to existing secret",
+                                    "type": "string",
+                                    "default": ""
+                                },
+                                "value": {
+                                    "title": "Instead of generating a secret value, use fo;lowing value",
+                                    "type": "string",
+                                    "default": ""
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -17,6 +17,17 @@ global:
   clusterRouterBase: apps.example.com
   # -- Custom hostname shorthand, overrides `global.clusterRouterBase`, `upstream.ingress.host`, `route.host`, and url values in `upstream.backstage.appConfig`
   host: ""
+  # -- Enable service authentication within Backstage instance
+  auth:
+    # -- Backend service to service authentication
+    # <br /> Ref: https://backstage.io/docs/auth/service-to-service-auth/
+    backend:
+      # -- Enable backend service to service authentication, unless configured otherwise it generates a secret value
+      enabled: true
+      # -- Instead of generating a secret value, refer to existing secret
+      existingSecret: ""
+      # -- Instead of generating a secret value, use fo;lowing value
+      value: ""
 
 # -- Upstream Backstage [chart configuration](https://github.com/backstage/charts/blob/main/charts/backstage/values.yaml)
 # @default -- Use Openshift compatible settings
@@ -47,6 +58,9 @@ upstream:
           connection:
             password: ${POSTGRESQL_ADMIN_PASSWORD}
             user: postgres
+        auth:
+          keys:
+            - secret: ${BACKEND_SECRET}
     readinessProbe:
       failureThreshold: 3
       httpGet:
@@ -68,6 +82,11 @@ upstream:
       successThreshold: 1
       timeoutSeconds: 2
     extraEnvVars:
+      - name: BACKEND_SECRET
+        valueFrom:
+          secretKeyRef:
+            key: backend-secret
+            name: '{{ include "janus-idp.backend-secret-name" $ }}'
       - name: POSTGRESQL_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves janus-idp/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

PR for the default image https://github.com/janus-idp/backstage-showcase/pull/694 introduced a [regression](https://github.com/janus-idp/backstage-showcase/pull/694/files#diff-dee2abe6cf6132866c815248b1ead4c4f5fef134a10bd0ddf1b88f1b3beac9feL13-L15). This forced me to implement this feature into our chart. After all, it may be useful, to provide this to all users.

## Existing or Associated Issue(s)

<!-- List any related issues. -->

## Additional Information

 <!-- Provide as much information that you feel would be helpful for those reviewing the proposed changes. -->

## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [x] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
