### PR TITLE
chore: use shell script to install dynamic plugins

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -41,4 +41,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.10.3
+version: 2.10.4

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Janus-IDP Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/janus-idp&style=flat-square)](https://artifacthub.io/packages/search?repo=janus-idp)
-![Version: 2.10.3](https://img.shields.io/badge/Version-2.10.3-informational?style=flat-square)
+![Version: 2.10.4](https://img.shields.io/badge/Version-2.10.4-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/values.yaml
+++ b/charts/backstage/values.yaml
@@ -135,8 +135,7 @@ upstream:
         # @default -- `quay.io/janus-idp/backstage-showcase:latest`
         image: '{{ include "backstage.image" . }}'
         command:
-          - python
-          - install-dynamic-plugins.py
+          - ./install-dynamic-plugins.sh
           - /dynamic-plugins-root
         env:
           - name: NPM_CONFIG_USERCONFIG


### PR DESCRIPTION
We should use the shell script to install dynamic plugins, to not have the helm chart assume the availability of the `python` command.