### PR TITLE
fix: enforce defaults in OCP form view

### DIFF
--- a/charts/backstage/Chart.yaml
+++ b/charts/backstage/Chart.yaml
@@ -41,4 +41,4 @@ sources:
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.10.4
+version: 2.10.5

--- a/charts/backstage/README.md
+++ b/charts/backstage/README.md
@@ -2,7 +2,7 @@
 # Janus-IDP Backstage Helm Chart
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/janus-idp&style=flat-square)](https://artifacthub.io/packages/search?repo=janus-idp)
-![Version: 2.10.4](https://img.shields.io/badge/Version-2.10.4-informational?style=flat-square)
+![Version: 2.10.5](https://img.shields.io/badge/Version-2.10.5-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for deploying a Backstage application

--- a/charts/backstage/values.schema.json
+++ b/charts/backstage/values.schema.json
@@ -41,7 +41,9 @@
                     "additionalProperties": false,
                     "properties": {
                         "includes": {
-                            "default": [],
+                            "default": [
+                                "dynamic-plugins.default.yaml"
+                            ],
                             "items": {
                                 "type": "string"
                             },
@@ -98,12 +100,12 @@
                     "type": "object"
                 },
                 "enabled": {
-                    "default": false,
+                    "default": true,
                     "title": "Enable the creation of the route resource.",
                     "type": "boolean"
                 },
                 "host": {
-                    "default": "",
+                    "default": "{{ .Values.global.host }}",
                     "examples": [
                         "https://bakstage.example.com"
                     ],
@@ -134,7 +136,7 @@
                             "type": "string"
                         },
                         "enabled": {
-                            "default": false,
+                            "default": true,
                             "title": "Enable TLS configuration for the host defined at `route.host` parameter.",
                             "type": "boolean"
                         },
@@ -194,7 +196,30 @@
                             "type": "object"
                         },
                         "appConfig": {
-                            "default": {},
+                            "default": {
+                                "app": {
+                                    "baseUrl": "https://{{- include \"janus-idp.hostname\" . }}"
+                                },
+                                "backend": {
+                                    "auth": {
+                                        "keys": [
+                                            {
+                                                "secret": "${BACKEND_SECRET}"
+                                            }
+                                        ]
+                                    },
+                                    "baseUrl": "https://{{- include \"janus-idp.hostname\" . }}",
+                                    "cors": {
+                                        "origin": "https://{{- include \"janus-idp.hostname\" . }}"
+                                    },
+                                    "database": {
+                                        "connection": {
+                                            "password": "${POSTGRESQL_ADMIN_PASSWORD}",
+                                            "user": "postgres"
+                                        }
+                                    }
+                                }
+                            },
                             "examples": [
                                 {
                                     "app": {
@@ -209,7 +234,10 @@
                             ]
                         },
                         "args": {
-                            "default": [],
+                            "default": [
+                                "--config",
+                                "dynamic-plugins-root/app-config.dynamic-plugins.yaml"
+                            ],
                             "items": {
                                 "type": "string"
                             },
@@ -217,10 +245,7 @@
                             "type": "array"
                         },
                         "command": {
-                            "default": [
-                                "node",
-                                "packages/backend"
-                            ],
+                            "default": [],
                             "items": {
                                 "type": "string"
                             },
@@ -1541,7 +1566,26 @@
                             "type": "array"
                         },
                         "extraEnvVars": {
-                            "default": [],
+                            "default": [
+                                {
+                                    "name": "BACKEND_SECRET",
+                                    "valueFrom": {
+                                        "secretKeyRef": {
+                                            "key": "backend-secret",
+                                            "name": "{{ include \"janus-idp.backend-secret-name\" $ }}"
+                                        }
+                                    }
+                                },
+                                {
+                                    "name": "POSTGRESQL_ADMIN_PASSWORD",
+                                    "valueFrom": {
+                                        "secretKeyRef": {
+                                            "key": "postgres-password",
+                                            "name": "{{ .Release.Name }}-postgresql"
+                                        }
+                                    }
+                                }
+                            ],
                             "examples": [
                                 [
                                     {
@@ -1681,7 +1725,12 @@
                             "type": "array"
                         },
                         "extraVolumeMounts": {
-                            "default": [],
+                            "default": [
+                                {
+                                    "mountPath": "/opt/app-root/src/dynamic-plugins-root",
+                                    "name": "dynamic-plugins-root"
+                                }
+                            ],
                             "items": {
                                 "description": "VolumeMount describes a mounting of a Volume within a container.",
                                 "properties": {
@@ -1720,7 +1769,41 @@
                             "type": "array"
                         },
                         "extraVolumes": {
-                            "default": [],
+                            "default": [
+                                {
+                                    "ephemeral": {
+                                        "volumeClaimTemplate": {
+                                            "spec": {
+                                                "accessModes": [
+                                                    "ReadWriteOnce"
+                                                ],
+                                                "resources": {
+                                                    "requests": {
+                                                        "storage": "1Gi"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "name": "dynamic-plugins-root"
+                                },
+                                {
+                                    "configMap": {
+                                        "defaultMode": 420,
+                                        "name": "dynamic-plugins",
+                                        "optional": true
+                                    },
+                                    "name": "dynamic-plugins"
+                                },
+                                {
+                                    "name": "dynamic-plugins-npmrc",
+                                    "secret": {
+                                        "defaultMode": 420,
+                                        "optional": true,
+                                        "secretName": "dynamic-plugins-npmrc"
+                                    }
+                                }
+                            ],
                             "items": {
                                 "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
                                 "properties": {
@@ -3242,7 +3325,7 @@
                                     "type": "array"
                                 },
                                 "registry": {
-                                    "default": "ghcr.io",
+                                    "default": "quay.io",
                                     "examples": [
                                         "ghcr.io",
                                         "quay.io",
@@ -3252,7 +3335,7 @@
                                     "type": "string"
                                 },
                                 "repository": {
-                                    "default": "backstage/backstage",
+                                    "default": "janus-idp/backstage-showcase",
                                     "title": "Backstage image repository",
                                     "type": "string"
                                 },
@@ -3267,7 +3350,42 @@
                             "type": "object"
                         },
                         "initContainers": {
-                            "default": [],
+                            "default": [
+                                {
+                                    "command": [
+                                        "./install-dynamic-plugins.sh",
+                                        "/dynamic-plugins-root"
+                                    ],
+                                    "env": [
+                                        {
+                                            "name": "NPM_CONFIG_USERCONFIG",
+                                            "value": "/opt/app-root/src/.npmrc.dynamic-plugins"
+                                        }
+                                    ],
+                                    "image": "{{ include \"backstage.image\" . }}",
+                                    "imagePullPolicy": "Always",
+                                    "name": "install-dynamic-plugins",
+                                    "volumeMounts": [
+                                        {
+                                            "mountPath": "/dynamic-plugins-root",
+                                            "name": "dynamic-plugins-root"
+                                        },
+                                        {
+                                            "mountPath": "/opt/app-root/src/dynamic-plugins.yaml",
+                                            "name": "dynamic-plugins",
+                                            "readOnly": true,
+                                            "subPath": "dynamic-plugins.yaml"
+                                        },
+                                        {
+                                            "mountPath": "/opt/app-root/src/.npmrc.dynamic-plugins",
+                                            "name": "dynamic-plugins-npmrc",
+                                            "readOnly": true,
+                                            "subPath": ".npmrc"
+                                        }
+                                    ],
+                                    "workingDir": "/opt/app-root/src"
+                                }
+                            ],
                             "items": {
                                 "description": "A single application container that you want to run within a pod.",
                                 "properties": {
@@ -4428,7 +4546,7 @@
                             "type": "array"
                         },
                         "installDir": {
-                            "default": "/app",
+                            "default": "/opt/app-root/src",
                             "title": "Directory containing the backstage installation",
                             "type": "string"
                         },
@@ -4580,7 +4698,9 @@
                             "additionalProperties": {
                                 "type": "string"
                             },
-                            "default": {},
+                            "default": {
+                                "checksum/dynamic-plugins": "{{- include \"common.tplvalues.render\" ( dict \"value\" .Values.global.dynamic \"context\" $) | sha256sum }}"
+                            },
                             "title": "Annotations to add to the backend deployment pods",
                             "type": "object"
                         },
@@ -5209,7 +5329,7 @@
                             "type": "boolean"
                         },
                         "host": {
-                            "default": "",
+                            "default": "{{ .Values.global.host }}",
                             "examples": [
                                 "backstage.10.0.0.1.nip.io"
                             ],
@@ -5296,7 +5416,7 @@
                     "type": "object"
                 },
                 "nameOverride": {
-                    "default": "",
+                    "default": "backstage",
                     "title": "String to partially override common.names.fullname",
                     "type": "string"
                 },


### PR DESCRIPTION
<!--
Thank you for your contribution! Complete the following fields to provide insight into the changes being requested as well as steps that you can take to ensure it meets all of the requirements

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves janus-idp/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure there are no merge commits!

 -->

## Description of the change

OCP Console is acting strangely when we want to default to `[]`, it assumes it's `null` and pulls data from the schema. This PR should ensure the schema is always consistent with default values in the chart, including values for subcharts.

## Existing or Associated Issue(s)

Fixes: #151 

## Additional Information

https://github.com/janus-idp/helm-backstage/assets/7453394/e2709f02-0665-4954-ac15-2beb327e37ab


## Checklist

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [x] Variables are documented in the `values.yaml` and added to the README.md. The [pre-commit](https://pre-commit.com/) utility can be used to generate the necessary content. Use `pre-commit run -a` to apply changes.
- [x] JSON Schema template updated and re-generated the raw schema via `pre-commit` hook.
- [x] List tests pass for Chart using the [Chart Testing](https://github.com/helm/chart-testing) tool and the `ct lint` command.
